### PR TITLE
Add name for wildcard express path

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -123,7 +123,7 @@ function Server(contentDirectory, lambdaApi, logger) {
     const sortedPathKeys = Object.keys(routes[method]).sort((a, b) => a.split('/').length - b.split('/').length || a.split('{').length - b.split('{').length);
     sortedPathKeys.map(resource => {
       let isProxy = resource.match(/{proxy\+}/);
-      let expressResource = resource.replace(/{proxy\+}/, '*').replace(/{([^{}]+)}/g, ':$1');
+      let expressResource = resource.replace(/{proxy\+}/, '*proxy').replace(/{([^{}]+)}/g, ':$1');
       api.all(expressResource, async (req, res) => {
         let event = {
           resource: resource,


### PR DESCRIPTION
Running a openapi-factory api locally fails when it has a {proxy+} route.

Turned out express 5 requires a name for wildcard paths:
https://expressjs.com/en/guide/migrating-5.html#path-syntax

> The wildcard `*` must have a name, matching the behavior of parameters `:`, use `/*splat` instead of `/*`
